### PR TITLE
Solve SSL_ERROR_HANDSHAKE_FAILURE_ALERT

### DIFF
--- a/exercises/03/Dockerfile
+++ b/exercises/03/Dockerfile
@@ -43,4 +43,5 @@ CMD /opt/sapjvm_8/bin/java \
 	-Dosgi.usesLimit=30 \
 	-Djava.awt.headless=true \
 	-Dio.netty.recycler.maxCapacity.default=256 \
+	-Djdk.tls.server.protocols=TLSv1.2 \
 	-jar plugins/org.eclipse.equinox.launcher_1.1.0.v20100507.jar


### PR DESCRIPTION
Error SSL_ERROR_HANDSHAKE_FAILURE_ALERT accessing cloud connector webui on port 8443.
Forced to TLSv1.2, see also 2958529 - Connection to administration UI of Cloud Connector fails.